### PR TITLE
Update deprecated in v13.0.0 options of the alter method

### DIFF
--- a/test/spec/altering.spec.js
+++ b/test/spec/altering.spec.js
@@ -9,7 +9,7 @@ describe('altering a table', () => {
     await runSample({
       id: 'altering.creating-row-top',
       execute: () => {
-        browser.executeScript(`hot.alter('insert_row', 1, 5)`);
+        browser.executeScript(`hot.alter('insert_row_above', 1, 5)`);
       },
     });
   });
@@ -21,7 +21,7 @@ describe('altering a table', () => {
     await runSample({
       id: 'altering.creating-column-top',
       execute: () => {
-        browser.executeScript(`hot.alter('insert_col', 1, 5)`);
+        browser.executeScript(`hot.alter('insert_col_start', 1, 5)`);
       },
     });
   });


### PR DESCRIPTION
This PR updates two [deprecated](https://github.com/handsontable/handsontable/pull/10407) option of alter method used in test. 

According to https://github.com/handsontable/handsontable/pull/9955
- `insert_row` was changed to `insert_row_above` 
- `insert_row` to `insert_row_above`


Adjustment was needed for testing version 13.0 and will probably come in handy in the future.